### PR TITLE
Add a common nasalization process

### DIFF
--- a/engine/data/rules.yaml
+++ b/engine/data/rules.yaml
@@ -372,6 +372,23 @@
     positive:
       - deletion
 
+- name: Nasal Elision
+  description: Nasal consonants are lost after nasal vowels.
+  before:
+    positive:
+      - syllabic
+      - nasal
+  after:
+    negative:
+      - syllabic
+  conditions:
+    positive:
+      - consonantal
+      - nasal
+  applies:
+    positive:
+      - deletion
+
 ##############################################################################
 ## CONSONANTS - FORTITION
 ##############################################################################
@@ -443,7 +460,7 @@
 ##############################################################################
 ## VOWELS
 ##############################################################################
-- name: Vowel Nasalization
+- name: Progressive Vowel Nasalization
   description: Vowels become nasalized after nasal consonants.
   conditions:
     positive:
@@ -451,6 +468,20 @@
     negative:
       - nasal
   before:
+    positive:
+      - nasal
+  applies:
+    positive:
+      - nasal
+
+- name: Regressive Vowel Nasalization
+  description: Vowels become nasalized before nasal consonants.
+  conditions:
+    positive:
+      - syllabic
+    negative:
+      - nasal
+  after:
     positive:
       - nasal
   applies:

--- a/engine/segment.py
+++ b/engine/segment.py
@@ -1,3 +1,6 @@
+from deparse import feature_order
+
+
 class Segment:
     '''A representation of a phonetic segment, stored in terms of features.'''
 
@@ -91,3 +94,8 @@ class Segment:
     def __repr__(self):
         return '<Segment> Positive: {0}, Negative: {1}'.format(self._positive,
                                                                self._negative)
+
+
+# A pseudo-segment that has all negative features, representing
+# a word boundary
+boundary = Segment(positive=[], negative=feature_order)

--- a/engine/word.py
+++ b/engine/word.py
@@ -1,4 +1,4 @@
-from segment import Segment
+from segment import Segment, boundary
 
 
 class Word:
@@ -44,17 +44,19 @@ class Word:
 
         if 'before' in rule:
             if index == 0:
-                return False
+                before_segment = boundary
+            else:
+                before_segment = self.segments[index - 1]
 
-            before_segment = self.segments[index - 1]
             if not before_segment.meets_conditions(rule['before']):
                 return False
 
         if 'after' in rule:
             if index == len(self.segments) - 1:
-                return False
+                after_segment = boundary
+            else:
+                after_segment = self.segments[index + 1]
 
-            after_segment = self.segments[index + 1]
             if not after_segment.meets_conditions(rule['after']):
                 return False
 


### PR DESCRIPTION
Was having fun with the site and noticed that one of my favorite sound changes (a very common one, showing up independently in the history of French, Hindi, and some Chinese dialects) wasn't possible in the rules available. So I added it :smiley: 

The rule is: VN → ṼN → Ṽ. Example (Chinese, Kunming dialect): 人 [ʐən] → [ʐə̃]